### PR TITLE
feat: add Plans, FAQ, and Legal pages + wire up CTA button

### DIFF
--- a/src/app/faq/page.tsx
+++ b/src/app/faq/page.tsx
@@ -1,0 +1,104 @@
+import Link from 'next/link';
+import { Button } from '@/components/ui/button';
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from '@/components/ui/accordion';
+
+const faqs = [
+  {
+    id: 'q1',
+    question: '¿Qué incluye cada servicio?',
+    answer:
+      'Cada servicio está diseñado para cubrir una necesidad específica. El plan de Entrenamiento Personalizado incluye programación detallada, control de cargas y ajustes semanales. La Asesoría Nutricional incluye un menú personalizado, recomendaciones según tus objetivos e integración con tu entrenamiento. El Programa Integral 4R lo combina todo: entrenamiento, nutrición y hábitos saludables, con soporte ampliado y videollamadas mensuales. Puedes consultar el detalle completo en la página de <a href="/planes" class="text-primary underline">Planes y Tarifas</a>.',
+  },
+  {
+    id: 'q2',
+    question: '¿Cómo funciona el proceso de incorporación?',
+    answer:
+      'Todo empieza con una sesión de diagnóstico gratuita (online o presencial) en la que analizamos tu situación actual, tus objetivos y tu historial. A partir de ahí, diseño tu plan personalizado y te lo entrego con una explicación detallada para que puedas empezar de inmediato.',
+  },
+  {
+    id: 'q3',
+    question: '¿Cuánto tiempo tardará en recibir mi plan personalizado?',
+    answer:
+      'Una vez realizada la sesión de diagnóstico y recibida toda la información necesaria, entrego el plan en un plazo máximo de 48–72 horas.',
+  },
+  {
+    id: 'q4',
+    question: '¿Puede adaptarse el plan a intolerancias o alergias alimentarias?',
+    answer:
+      'Sí, absolutamente. Durante la sesión inicial recogemos toda la información sobre tus preferencias, intolerancias, alergias y restricciones dietéticas para garantizar que el plan sea seguro, práctico y disfrutable.',
+  },
+  {
+    id: 'q5',
+    question: '¿Cómo se realiza el seguimiento y el soporte (chat, videollamada...)?',
+    answer:
+      'El seguimiento se realiza principalmente a través de mensajería (WhatsApp o la plataforma acordada). En el Programa Integral 4R se incluye además una videollamada mensual en profundidad de 30–45 minutos. El horario de atención es de lunes a viernes de 08:00 a 19:00, con respuesta garantizada en 24–48 horas.',
+  },
+  {
+    id: 'q6',
+    question: '¿Qué ocurre si quiero cancelar?',
+    answer:
+      'Puedes cancelar tu plan en cualquier momento. Los detalles exactos sobre periodos de preaviso y política de reembolso se especifican en los <a href="/legal" class="text-primary underline">Términos y Condiciones</a>. Si tienes cualquier duda antes de contratar, no dudes en consultármelo.',
+  },
+  {
+    id: 'q7',
+    question: '¿Necesito equipamiento de gimnasio o puedo entrenar en casa?',
+    answer:
+      'Los programas se adaptan a tu situación. Puedes entrenar en casa con material mínimo (mancuernas, bandas elásticas, tu propio peso corporal) o en un gimnasio completo. Indícame tu contexto durante la sesión de diagnóstico y diseñaré el plan en consecuencia.',
+  },
+  {
+    id: 'q8',
+    question: '¿Está incluida la asesoría nutricional en todos los planes?',
+    answer:
+      'La asesoría nutricional completa está incluida en el plan de Asesoría Nutricional y en el Programa Integral 4R. En el plan de Entrenamiento Personalizado se ofrecen orientaciones generales sobre alimentación, pero el diseño detallado del menú corresponde al servicio de nutrición.',
+  },
+];
+
+export default function FaqPage() {
+  return (
+    <div className="container mx-auto px-4 sm:px-6 lg:px-8 py-16 max-w-3xl">
+      <div className="text-center mb-12">
+        <h1 className="font-headline text-4xl md:text-5xl font-bold">Preguntas Frecuentes</h1>
+        <p className="mt-4 text-lg text-muted-foreground">
+          Respuestas a las dudas más habituales. Si no encuentras lo que buscas, escríbeme
+          directamente.
+        </p>
+      </div>
+
+      <Accordion type="single" collapsible className="w-full">
+        {faqs.map((faq) => (
+          <AccordionItem key={faq.id} value={faq.id}>
+            <AccordionTrigger className="text-left text-base font-semibold">
+              {faq.question}
+            </AccordionTrigger>
+            <AccordionContent>
+              <p
+                className="text-muted-foreground leading-relaxed"
+                dangerouslySetInnerHTML={{ __html: faq.answer }}
+              />
+            </AccordionContent>
+          </AccordionItem>
+        ))}
+      </Accordion>
+
+      <div className="text-center mt-16">
+        <p className="text-muted-foreground mb-4">
+          ¿Tienes más preguntas? Contáctame directamente.
+        </p>
+        <Button asChild size="lg">
+          <a href="/#contact">Agenda tu Sesión de Diagnóstico GRATUITA</a>
+        </Button>
+      </div>
+
+      <div className="text-center mt-8">
+        <Button asChild variant="ghost">
+          <Link href="/">← Volver al inicio</Link>
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/legal/page.tsx
+++ b/src/app/legal/page.tsx
@@ -1,0 +1,179 @@
+import Link from 'next/link';
+import { Button } from '@/components/ui/button';
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from '@/components/ui/accordion';
+
+export default function LegalPage() {
+  return (
+    <div className="container mx-auto px-4 sm:px-6 lg:px-8 py-16 max-w-3xl">
+      <div className="text-center mb-12">
+        <h1 className="font-headline text-4xl md:text-5xl font-bold">Legal</h1>
+        <p className="mt-4 text-lg text-muted-foreground">
+          Política de Privacidad y Términos y Condiciones
+        </p>
+      </div>
+
+      <Accordion type="multiple" className="w-full space-y-2">
+
+        {/* PRIVACY POLICY */}
+        <AccordionItem value="privacidad">
+          <AccordionTrigger className="text-xl font-headline font-bold">
+            Política de Privacidad
+          </AccordionTrigger>
+          <AccordionContent className="prose prose-sm max-w-none text-muted-foreground space-y-4">
+            <div className="space-y-4">
+              <section>
+                <h3 className="font-semibold text-foreground">1. Responsable del tratamiento</h3>
+                <p>
+                  <strong>Nombre / Razón social:</strong> [FILL IN]<br />
+                  <strong>NIF/CIF:</strong> [FILL IN]<br />
+                  <strong>Domicilio:</strong> [FILL IN]<br />
+                  <strong>Correo electrónico de contacto:</strong> [FILL IN]
+                </p>
+              </section>
+
+              <section>
+                <h3 className="font-semibold text-foreground">2. Datos que recogemos</h3>
+                <p>
+                  A través de los formularios de esta web podemos recabar los siguientes datos personales:
+                  nombre y apellidos, dirección de correo electrónico, número de teléfono (si se facilita)
+                  y cualquier otro dato que el usuario aporte voluntariamente en el mensaje de contacto.
+                  Asimismo, podemos tratar datos relativos a la salud y condición física cuando sean
+                  necesarios para prestar los servicios contratados, siempre con consentimiento explícito
+                  del interesado.
+                </p>
+              </section>
+
+              <section>
+                <h3 className="font-semibold text-foreground">3. Finalidad y base jurídica del tratamiento</h3>
+                <ul className="list-disc pl-5 space-y-1">
+                  <li>Gestionar las consultas y solicitudes de información: interés legítimo / consentimiento del usuario (art. 6.1.a y 6.1.f RGPD).</li>
+                  <li>Prestación de los servicios contratados: ejecución de contrato (art. 6.1.b RGPD).</li>
+                  <li>Envío de comunicaciones comerciales: consentimiento expreso (art. 6.1.a RGPD). Puedes retirar el consentimiento en cualquier momento.</li>
+                </ul>
+              </section>
+
+              <section>
+                <h3 className="font-semibold text-foreground">4. Conservación de los datos</h3>
+                <p>
+                  Los datos se conservarán durante el tiempo necesario para cumplir con la finalidad
+                  para la que fueron recabados y, en todo caso, durante los plazos legalmente establecidos.
+                </p>
+              </section>
+
+              <section>
+                <h3 className="font-semibold text-foreground">5. Destinatarios</h3>
+                <p>
+                  Los datos no se cederán a terceros salvo obligación legal. Se podrán utilizar
+                  encargados de tratamiento (herramientas de email, CRM, etc.) que actúan bajo contrato
+                  de encargo de tratamiento conforme al RGPD.
+                </p>
+              </section>
+
+              <section>
+                <h3 className="font-semibold text-foreground">6. Derechos del usuario</h3>
+                <p>
+                  El usuario tiene derecho a acceder, rectificar y suprimir sus datos, así como a
+                  oponerse al tratamiento, solicitar la limitación y la portabilidad. Para ejercer
+                  estos derechos, diríjase a: <strong>[FILL IN correo electrónico]</strong>.
+                  También puede presentar una reclamación ante la Agencia Española de Protección de
+                  Datos (aepd.es).
+                </p>
+              </section>
+
+              <section>
+                <h3 className="font-semibold text-foreground">7. Política de cookies</h3>
+                <p>
+                  Esta web puede utilizar cookies técnicas necesarias para el funcionamiento del sitio.
+                  [FILL IN política de cookies detallada si se usan cookies analíticas o de marketing.]
+                </p>
+              </section>
+            </div>
+          </AccordionContent>
+        </AccordionItem>
+
+        {/* TERMS OF SERVICE */}
+        <AccordionItem value="terminos">
+          <AccordionTrigger className="text-xl font-headline font-bold">
+            Términos y Condiciones
+          </AccordionTrigger>
+          <AccordionContent className="prose prose-sm max-w-none text-muted-foreground space-y-4">
+            <div className="space-y-4">
+              <section>
+                <h3 className="font-semibold text-foreground">1. Descripción del servicio</h3>
+                <p>
+                  entrenaconDiego ofrece servicios de entrenamiento personal personalizado, asesoría
+                  nutricional y programas integrales de hábitos saludables, prestados de forma online
+                  y/o presencial según lo acordado con el cliente.
+                </p>
+              </section>
+
+              <section>
+                <h3 className="font-semibold text-foreground">2. Contratación y pago</h3>
+                <p>
+                  La relación contractual se formaliza mediante la aceptación del presupuesto enviado
+                  al cliente y el abono del pago correspondiente. El precio del servicio es el indicado
+                  en dicho presupuesto. <strong>[FILL IN métodos de pago aceptados.]</strong>
+                </p>
+              </section>
+
+              <section>
+                <h3 className="font-semibold text-foreground">3. Política de reembolso</h3>
+                <p>
+                  [FILL IN política de reembolso: condiciones, plazos y excepciones aplicables.]
+                  Con carácter general, los servicios de planificación ya entregados no son reembolsables
+                  al tratarse de trabajo personalizado ya realizado.
+                </p>
+              </section>
+
+              <section>
+                <h3 className="font-semibold text-foreground">4. Cancelación</h3>
+                <p>
+                  El cliente puede cancelar el servicio en cualquier momento mediante comunicación
+                  escrita con un preaviso mínimo de <strong>[FILL IN número de días]</strong> días.
+                  Las cancelaciones con menos preaviso podrán conllevar la facturación del periodo
+                  correspondiente según lo acordado.
+                </p>
+              </section>
+
+              <section>
+                <h3 className="font-semibold text-foreground">5. Limitación de responsabilidad</h3>
+                <p>
+                  Los servicios de entrenamiento y nutrición tienen carácter orientativo y no
+                  sustituyen el consejo médico profesional. El cliente es responsable de comunicar
+                  cualquier condición médica preexistente antes de iniciar el programa. entrenaconDiego
+                  no se responsabiliza de lesiones derivadas del incumplimiento de las indicaciones
+                  proporcionadas.
+                </p>
+              </section>
+
+              <section>
+                <h3 className="font-semibold text-foreground">6. Ley aplicable y jurisdicción</h3>
+                <p>
+                  Estos términos se rigen por la legislación española. Para cualquier controversia,
+                  las partes se someten a los juzgados y tribunales de <strong>[FILL IN ciudad]</strong>,
+                  salvo que la normativa de consumidores establezca otro fuero.
+                </p>
+              </section>
+            </div>
+          </AccordionContent>
+        </AccordionItem>
+      </Accordion>
+
+      <p className="mt-8 text-sm text-muted-foreground text-center">
+        Para cualquier consulta sobre esta política, escríbenos a{' '}
+        <strong>[FILL IN correo electrónico]</strong>.
+      </p>
+
+      <div className="text-center mt-8">
+        <Button asChild variant="ghost">
+          <Link href="/">← Volver al inicio</Link>
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/planes/page.tsx
+++ b/src/app/planes/page.tsx
@@ -1,0 +1,170 @@
+import Link from 'next/link';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from '@/components/ui/accordion';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
+import { CheckCircle2, Dumbbell, Apple, Star } from 'lucide-react';
+
+const services = [
+  {
+    id: 'entrenamiento',
+    icon: <Dumbbell className="h-8 w-8 text-primary" />,
+    title: 'Programas de Entrenamiento Personalizados con Rigor de Ingeniero',
+    subtitle: 'Entrenamiento Personalizado',
+    description:
+      'No más entrenamientos genéricos. Recibe un plan de fitness totalmente individualizado basado en tus objetivos específicos (pérdida de peso, fuerza, resistencia en montaña o running). Te guiaré paso a paso, aplicando la progresión lógica que garantiza resultados.',
+    price: '[PRICE]',
+    features: [
+      { category: 'Entrenamiento', items: [
+        'Planificación del entrenamiento detallada 100% a medida',
+        'Control de cargas, volumen, intensidad y progresión',
+        'Explicación de variables de entrenamiento',
+        'Ajustes semanales según evolución',
+        'Análisis de técnica por vídeo (opcional)',
+      ]},
+    ],
+  },
+  {
+    id: 'nutricion',
+    icon: <Apple className="h-8 w-8 text-primary" />,
+    title: 'Diseño de una Dieta Personalizada y Saludable para una Vida de Alto Rendimiento',
+    subtitle: 'Asesoría Nutricional',
+    description:
+      'Un plan dietético integral que va más allá del gimnasio. Diseñamos juntos una estrategia nutricional adaptada a tu estilo de vida, tus preferencias y tus objetivos de salud y rendimiento.',
+    price: '[PRICE]',
+    features: [
+      { category: 'Nutrición', items: [
+        'Menú 100% personalizado',
+        'Explicación de aplicación diaria',
+        'Recomendaciones según estado y objetivos',
+        'Integración con entrenamiento',
+        'Asesoramiento en suplementación (si necesario)',
+      ]},
+    ],
+  },
+  {
+    id: 'integral',
+    icon: <Star className="h-8 w-8 text-primary" />,
+    title: 'Entrenamiento, Nutrición y Hábitos: Tu Plan Estratégico hacia Resultados Duraderos',
+    subtitle: 'Programa Integral 4R',
+    description:
+      'No se trata de hacer más, sino de hacerlo mejor. El Programa 4R combina entrenamiento, nutrición y hábitos en un único plan estratégico diseñado para que obtengas resultados duraderos y construyas una vida de alto rendimiento.',
+    price: '[PRICE]',
+    badge: 'Todo incluido',
+    features: [
+      { category: 'Entrenamiento', items: [
+        'Planificación del entrenamiento detallada 100% a medida',
+        'Control de cargas, volumen, intensidad y progresión',
+        'Explicación de variables de entrenamiento',
+        'Ajustes semanales según evolución',
+        'Análisis de técnica por vídeo (opcional)',
+      ]},
+      { category: 'Nutrición', items: [
+        'Menú 100% personalizado',
+        'Explicación de aplicación diaria',
+        'Recomendaciones según estado y objetivos',
+        'Integración con entrenamiento',
+        'Asesoramiento en suplementación para salud y longevidad',
+      ]},
+      { category: 'Hábitos y Salud', items: [
+        'Plan de hábitos saludables',
+        'Revisión opcional de analíticas',
+      ]},
+      { category: 'Soporte Continuado', items: [
+        'Soporte ampliado: lunes a viernes 08:00–19:00',
+        'Videollamada mensual en profundidad (30–45 min)',
+        'Respuesta garantizada en 24–48 h',
+      ]},
+    ],
+  },
+];
+
+export default function PlanesPage() {
+  return (
+    <div className="container mx-auto px-4 sm:px-6 lg:px-8 py-16">
+      <div className="text-center max-w-3xl mx-auto mb-16">
+        <h1 className="font-headline text-4xl md:text-5xl font-bold">Planes y Tarifas</h1>
+        <p className="mt-4 text-lg text-muted-foreground">
+          Elige el programa que mejor se adapta a tus objetivos. Todos los planes incluyen
+          seguimiento personalizado y atención directa.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 gap-10 lg:grid-cols-3">
+        {services.map((service) => (
+          <Card key={service.id} className="flex flex-col shadow-lg relative">
+            {service.badge && (
+              <Badge className="absolute -top-3 left-1/2 -translate-x-1/2 bg-primary text-primary-foreground px-4 py-1 text-sm">
+                {service.badge}
+              </Badge>
+            )}
+            <CardHeader className="items-center text-center pt-8">
+              <div className="bg-primary/10 p-4 rounded-full mb-2">{service.icon}</div>
+              <p className="text-sm font-semibold text-primary uppercase tracking-wide">
+                {service.subtitle}
+              </p>
+              <CardTitle className="font-headline text-xl mt-1 leading-snug">
+                {service.title}
+              </CardTitle>
+            </CardHeader>
+
+            <CardContent className="flex flex-col flex-grow gap-6">
+              <CardDescription className="text-base">{service.description}</CardDescription>
+
+              <div className="text-center">
+                <span className="text-3xl font-bold">{service.price}</span>
+                <span className="text-muted-foreground text-sm ml-1">/ mes</span>
+              </div>
+
+              <Accordion type="single" collapsible className="w-full">
+                {service.features.map((group) => (
+                  <AccordionItem key={group.category} value={group.category}>
+                    <AccordionTrigger className="text-sm font-semibold">
+                      {group.category}
+                    </AccordionTrigger>
+                    <AccordionContent>
+                      <ul className="space-y-2">
+                        {group.items.map((item) => (
+                          <li key={item} className="flex items-start gap-2 text-sm">
+                            <CheckCircle2 className="h-4 w-4 text-primary shrink-0 mt-0.5" />
+                            <span>{item}</span>
+                          </li>
+                        ))}
+                      </ul>
+                    </AccordionContent>
+                  </AccordionItem>
+                ))}
+              </Accordion>
+
+              <div className="mt-auto pt-4">
+                <Button asChild className="w-full" size="lg">
+                  <a href="/#contact">Solicitar información</a>
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      <div className="text-center mt-16">
+        <p className="text-muted-foreground mb-4">
+          ¿No sabes qué plan elegir? Agenda una sesión de diagnóstico gratuita.
+        </p>
+        <Button asChild variant="outline" size="lg">
+          <a href="/#contact">Agenda tu Sesión de Diagnóstico GRATUITA</a>
+        </Button>
+      </div>
+
+      <div className="text-center mt-8">
+        <Button asChild variant="ghost">
+          <Link href="/">← Volver al inicio</Link>
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -1,24 +1,38 @@
+import Link from 'next/link';
 import { Instagram, Linkedin } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 
 const Footer = () => {
   return (
     <footer className="bg-muted text-muted-foreground">
-      <div className="container mx-auto px-4 sm:px-6 lg:px-8 py-8 flex flex-col sm:flex-row justify-between items-center">
-        <p className="text-sm text-center sm:text-left">
-          &copy; {new Date().getFullYear()} Diego Jimenez. Todos los derechos reservados.
-        </p>
-        <div className="flex items-center gap-2 mt-4 sm:mt-0">
-          <Button variant="ghost" size="icon" asChild>
-            <a href="#" aria-label="Instagram">
-              <Instagram className="h-5 w-5" />
-            </a>
-          </Button>
-          <Button variant="ghost" size="icon" asChild>
-            <a href="#" aria-label="LinkedIn">
-              <Linkedin className="h-5 w-5" />
-            </a>
-          </Button>
+      <div className="container mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <div className="flex flex-col sm:flex-row justify-between items-center gap-4">
+          <p className="text-sm text-center sm:text-left">
+            &copy; {new Date().getFullYear()} Diego Jimenez. Todos los derechos reservados.
+          </p>
+          <nav className="flex items-center gap-4 text-sm">
+            <Link href="/planes" className="hover:text-foreground transition-colors">
+              Planes y Tarifas
+            </Link>
+            <Link href="/faq" className="hover:text-foreground transition-colors">
+              FAQ
+            </Link>
+            <Link href="/legal" className="hover:text-foreground transition-colors">
+              Legal / Privacidad
+            </Link>
+          </nav>
+          <div className="flex items-center gap-2">
+            <Button variant="ghost" size="icon" asChild>
+              <a href="#" aria-label="Instagram">
+                <Instagram className="h-5 w-5" />
+              </a>
+            </Button>
+            <Button variant="ghost" size="icon" asChild>
+              <a href="#" aria-label="LinkedIn">
+                <Linkedin className="h-5 w-5" />
+              </a>
+            </Button>
+          </div>
         </div>
       </div>
     </footer>

--- a/src/components/sections/services-section.tsx
+++ b/src/components/sections/services-section.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { BrainCircuit, Dumbbell } from 'lucide-react';
@@ -45,7 +46,9 @@ const ServicesSection = () => {
           ))}
         </div>
         <div className="text-center mt-12">
-          <Button size="lg" variant="outline">Ver Planes y Tarifas</Button>
+          <Button size="lg" variant="outline" asChild>
+            <Link href="/planes">Ver Planes y Tarifas</Link>
+          </Button>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary

Resolves #1 and #2.

- **`/planes`** — New Plans & Pricing page with 3 service cards, each with an accordion listing included features. The "Programa Integral 4R" is visually highlighted with a badge. Price slots use `[PRICE]` placeholders.
- **`/faq`** — New FAQ page with 8 accordion Q&As drafted from existing site content, in a friendly first-person tone.
- **`/legal`** — New Legal page combining a GDPR/LOPD-compliant Privacy Policy and Terms of Service, with `[FILL IN]` placeholders for business-specific details.
- **`services-section.tsx`** — "Ver Planes y Tarifas" CTA button now links to `/planes`.
- **`footer.tsx`** — Footer now includes links to `/planes`, `/faq`, and `/legal` on every page.

## Test plan

- [ ] Visit `/planes` — all 3 service cards render; accordions expand/collapse; CTA links to `/#contact`
- [ ] Visit `/faq` — all 8 questions expand/collapse; links to `/planes` and `/legal` work
- [ ] Visit `/legal` — Privacy Policy and Terms sections expand; `[FILL IN]` placeholders visible for owner review
- [ ] Homepage "Ver Planes y Tarifas" button navigates to `/planes`
- [ ] Footer links to `/planes`, `/faq`, `/legal` on all pages
- [ ] Pages are responsive on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)