### PR TITLE
Fixes #6: Footer — update Instagram link and remove LinkedIn icon

### DIFF
--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link';
-import { Instagram, Linkedin } from 'lucide-react';
+import { Instagram } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 
 const Footer = () => {
@@ -23,13 +23,13 @@ const Footer = () => {
           </nav>
           <div className="flex items-center gap-2">
             <Button variant="ghost" size="icon" asChild>
-              <a href="#" aria-label="Instagram">
+              <a
+                href="https://www.instagram.com/entrenacondiego/"
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label="Instagram"
+              >
                 <Instagram className="h-5 w-5" />
-              </a>
-            </Button>
-            <Button variant="ghost" size="icon" asChild>
-              <a href="#" aria-label="LinkedIn">
-                <Linkedin className="h-5 w-5" />
               </a>
             </Button>
           </div>


### PR DESCRIPTION
## Problem

The footer's Instagram icon pointed to `#` (no URL) and the LinkedIn icon was present despite not being used.

## Changes

- **Instagram link**: Updated `href` to `https://www.instagram.com/entrenacondiego/`, added `target="_blank"` and `rel="noopener noreferrer"`, kept existing `aria-label="Instagram"`.
- **LinkedIn icon**: Removed the `<Button>` + `<a>` block entirely. Removed `Linkedin` from the `lucide-react` import — no unused imports remain.
- Footer flex layout is unchanged; the single remaining icon stays properly aligned on desktop and mobile.

## Testing

- TypeScript compile: passes (pre-existing unrelated `nodemailer` type error excluded).
- Clicking Instagram icon opens `https://www.instagram.com/entrenacondiego/` in a new tab.
- No LinkedIn icon in rendered DOM.
- Footer layout visually balanced with one icon.

Closes #6