### PR TITLE
Fixes #5: Pricing — replace [PRICE], remove single-group accordion, add nav entry

### DIFF
--- a/src/app/planes/page.tsx
+++ b/src/app/planes/page.tsx
@@ -10,7 +10,19 @@ import {
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 import { CheckCircle2, Dumbbell, Apple, Star } from 'lucide-react';
 
-const services = [
+type FeatureGroup = { category: string; items: string[] };
+
+type Service = {
+  id: string;
+  icon: React.ReactNode;
+  title: string;
+  subtitle: string;
+  description: string;
+  badge?: string;
+  features: FeatureGroup[];
+};
+
+const services: Service[] = [
   {
     id: 'entrenamiento',
     icon: <Dumbbell className="h-8 w-8 text-primary" />,
@@ -18,7 +30,6 @@ const services = [
     subtitle: 'Entrenamiento Personalizado',
     description:
       'No más entrenamientos genéricos. Recibe un plan de fitness totalmente individualizado basado en tus objetivos específicos (pérdida de peso, fuerza, resistencia en montaña o running). Te guiaré paso a paso, aplicando la progresión lógica que garantiza resultados.',
-    price: '[PRICE]',
     features: [
       { category: 'Entrenamiento', items: [
         'Planificación del entrenamiento detallada 100% a medida',
@@ -36,7 +47,6 @@ const services = [
     subtitle: 'Asesoría Nutricional',
     description:
       'Un plan dietético integral que va más allá del gimnasio. Diseñamos juntos una estrategia nutricional adaptada a tu estilo de vida, tus preferencias y tus objetivos de salud y rendimiento.',
-    price: '[PRICE]',
     features: [
       { category: 'Nutrición', items: [
         'Menú 100% personalizado',
@@ -54,7 +64,6 @@ const services = [
     subtitle: 'Programa Integral 4R',
     description:
       'No se trata de hacer más, sino de hacerlo mejor. El Programa 4R combina entrenamiento, nutrición y hábitos en un único plan estratégico diseñado para que obtengas resultados duraderos y construyas una vida de alto rendimiento.',
-    price: '[PRICE]',
     badge: 'Todo incluido',
     features: [
       { category: 'Entrenamiento', items: [
@@ -84,11 +93,55 @@ const services = [
   },
 ];
 
+function FeatureListExpanded({ groups }: { groups: FeatureGroup[] }) {
+  return (
+    <div className="w-full space-y-4">
+      {groups.map((group) => (
+        <div key={group.category}>
+          <p className="text-sm font-semibold mb-2">{group.category}</p>
+          <ul className="space-y-2">
+            {group.items.map((item) => (
+              <li key={item} className="flex items-start gap-2 text-sm">
+                <CheckCircle2 className="h-4 w-4 text-primary shrink-0 mt-0.5" />
+                <span>{item}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function FeatureListAccordion({ groups }: { groups: FeatureGroup[] }) {
+  return (
+    <Accordion type="single" collapsible className="w-full">
+      {groups.map((group) => (
+        <AccordionItem key={group.category} value={group.category}>
+          <AccordionTrigger className="text-sm font-semibold">
+            {group.category}
+          </AccordionTrigger>
+          <AccordionContent>
+            <ul className="space-y-2">
+              {group.items.map((item) => (
+                <li key={item} className="flex items-start gap-2 text-sm">
+                  <CheckCircle2 className="h-4 w-4 text-primary shrink-0 mt-0.5" />
+                  <span>{item}</span>
+                </li>
+              ))}
+            </ul>
+          </AccordionContent>
+        </AccordionItem>
+      ))}
+    </Accordion>
+  );
+}
+
 export default function PlanesPage() {
   return (
     <div className="container mx-auto px-4 sm:px-6 lg:px-8 py-16">
       <div className="text-center max-w-3xl mx-auto mb-16">
-        <h1 className="font-headline text-4xl md:text-5xl font-bold">Planes y Tarifas</h1>
+        <h1 id="planes-y-tarifas" className="font-headline text-4xl md:text-5xl font-bold">Planes y Tarifas</h1>
         <p className="mt-4 text-lg text-muted-foreground">
           Elige el programa que mejor se adapta a tus objetivos. Todos los planes incluyen
           seguimiento personalizado y atención directa.
@@ -96,59 +149,48 @@ export default function PlanesPage() {
       </div>
 
       <div className="grid grid-cols-1 gap-10 lg:grid-cols-3">
-        {services.map((service) => (
-          <Card key={service.id} className="flex flex-col shadow-lg relative">
-            {service.badge && (
-              <Badge className="absolute -top-3 left-1/2 -translate-x-1/2 bg-primary text-primary-foreground px-4 py-1 text-sm">
-                {service.badge}
-              </Badge>
-            )}
-            <CardHeader className="items-center text-center pt-8">
-              <div className="bg-primary/10 p-4 rounded-full mb-2">{service.icon}</div>
-              <p className="text-sm font-semibold text-primary uppercase tracking-wide">
-                {service.subtitle}
-              </p>
-              <CardTitle className="font-headline text-xl mt-1 leading-snug">
-                {service.title}
-              </CardTitle>
-            </CardHeader>
+        {services.map((service) => {
+          const useAccordion = service.features.length > 1;
+          return (
+            <Card key={service.id} className="flex flex-col shadow-lg relative">
+              {service.badge && (
+                <Badge className="absolute -top-3 left-1/2 -translate-x-1/2 bg-primary text-primary-foreground px-4 py-1 text-sm">
+                  {service.badge}
+                </Badge>
+              )}
+              <CardHeader className="items-center text-center pt-8">
+                <div className="bg-primary/10 p-4 rounded-full mb-2">{service.icon}</div>
+                <p className="text-sm font-semibold text-primary uppercase tracking-wide">
+                  {service.subtitle}
+                </p>
+                <CardTitle className="font-headline text-xl mt-1 leading-snug">
+                  {service.title}
+                </CardTitle>
+              </CardHeader>
 
-            <CardContent className="flex flex-col flex-grow gap-6">
-              <CardDescription className="text-base">{service.description}</CardDescription>
+              <CardContent className="flex flex-col flex-grow gap-6">
+                <CardDescription className="text-base">{service.description}</CardDescription>
 
-              <div className="text-center">
-                <span className="text-3xl font-bold">{service.price}</span>
-                <span className="text-muted-foreground text-sm ml-1">/ mes</span>
-              </div>
+                <div className="text-center">
+                  <Button asChild variant="outline" className="w-full">
+                    <a href="/#contact">Consultar precio</a>
+                  </Button>
+                </div>
 
-              <Accordion type="single" collapsible className="w-full">
-                {service.features.map((group) => (
-                  <AccordionItem key={group.category} value={group.category}>
-                    <AccordionTrigger className="text-sm font-semibold">
-                      {group.category}
-                    </AccordionTrigger>
-                    <AccordionContent>
-                      <ul className="space-y-2">
-                        {group.items.map((item) => (
-                          <li key={item} className="flex items-start gap-2 text-sm">
-                            <CheckCircle2 className="h-4 w-4 text-primary shrink-0 mt-0.5" />
-                            <span>{item}</span>
-                          </li>
-                        ))}
-                      </ul>
-                    </AccordionContent>
-                  </AccordionItem>
-                ))}
-              </Accordion>
+                {useAccordion
+                  ? <FeatureListAccordion groups={service.features} />
+                  : <FeatureListExpanded groups={service.features} />
+                }
 
-              <div className="mt-auto pt-4">
-                <Button asChild className="w-full" size="lg">
-                  <a href="/#contact">Solicitar información</a>
-                </Button>
-              </div>
-            </CardContent>
-          </Card>
-        ))}
+                <div className="mt-auto pt-4">
+                  <Button asChild className="w-full" size="lg">
+                    <a href="/#contact">Solicitar información</a>
+                  </Button>
+                </div>
+              </CardContent>
+            </Card>
+          );
+        })}
       </div>
 
       <div className="text-center mt-16">

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -10,6 +10,7 @@ const navLinks = [
   { href: "#about", label: "Sobre Mí" },
   { href: "#services", label: "Servicios" },
   { href: "#methodology", label: "Método" },
+  { href: "/planes#planes-y-tarifas", label: "Planes y Tarifas" },
   { href: "#contact", label: "Contacto" },
 ];
 


### PR DESCRIPTION
## Problem

Three separate UX issues in the Planes y Tarifas page:
1. `[PRICE] / mes` placeholder text was rendered literally in all three cards.
2. Cards 1 and 2 each had a single-group collapsible accordion — with only one section, the toggle adds no value.
3. The pricing page had no entry in the top navigation.

## Changes

### 1. Replace `[PRICE]` with "Consultar precio" button
- Removed the `price` field from the service data objects entirely (no hidden text nodes remain).
- Added a "Consultar precio" `Button` (`variant="outline"`) in the same vertical position, wired to `href="/#contact"` — same target as the existing "Solicitar información" CTA.

### 2. Simplified feature display for cards 1 & 2
- Extracted `<FeatureListExpanded>` (always visible, static heading, no chevron/click handler) and `<FeatureListAccordion>` (original accordion behavior) components.
- Cards with a single feature group (`features.length === 1`) render `FeatureListExpanded`.
- Card 3 (Programa Integral 4R, 4 groups) renders `FeatureListAccordion` unchanged.

### 3. Navigation entry
- Added `{ href: "/planes#planes-y-tarifas", label: "Planes y Tarifas" }` to `navLinks` in `header.tsx`, placed between "Método" and "Contacto".
- Added `id="planes-y-tarifas"` to the `<h1>` in the planes page so the anchor resolves correctly.
- Appears in both desktop nav and the mobile Sheet menu (driven by the same `navLinks` array).

## Testing

- TypeScript: `npx tsc --noEmit` passes (pre-existing `nodemailer` type error unrelated).
- Confirmed no instance of `[PRICE]` remains in the component tree.
- Cards 1 & 2 feature lists render expanded with no toggle.
- Card 3 retains accordion with 4 groups.
- "Planes y Tarifas" appears in desktop nav and mobile menu.

Closes #5