### PR TITLE
Fixes #7: Restructure Servicios (3-card) and Método 4R to connect pricing tiers

### DIFF
--- a/src/components/sections/methodology-section.tsx
+++ b/src/components/sections/methodology-section.tsx
@@ -1,49 +1,66 @@
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Target, Mountain, Repeat, TrendingUp } from 'lucide-react';
 
 const methodology = [
   {
-    icon: <Target className="h-8 w-8 text-primary" />,
-    title: 'Rigor (La Ingeniería)',
-    description: 'Análisis detallado de tu punto de partida. Definición de objetivos SMART y planificación milimétrica.',
+    icon: <Target className="h-6 w-6 text-primary" />,
+    letter: 'R1',
+    title: 'Rigor',
+    subtitle: 'La Ingeniería',
+    description: 'Análisis detallado de tu punto de partida. Objetivos SMART y planificación milimétrica.',
   },
   {
-    icon: <Mountain className="h-8 w-8 text-primary" />,
-    title: 'Resistencia (Los 20 Años)',
-    description: 'Programas diseñados para construir una base física y mental a prueba de fallos. Entrenamiento funcional y de fuerza basado en la longevidad.',
+    icon: <Mountain className="h-6 w-6 text-primary" />,
+    letter: 'R2',
+    title: 'Resistencia',
+    subtitle: 'Los 20 Años',
+    description: 'Entrenamiento funcional y de fuerza orientado a la longevidad. Base física a prueba de fallos.',
   },
   {
-    icon: <Repeat className="h-8 w-8 text-primary" />,
-    title: 'Rutina (Los Hábitos)',
-    description: 'Implementación de microrrutinas que transforman tu día a día, haciendo que el bienestar sea automático, no una lucha.',
+    icon: <Repeat className="h-6 w-6 text-primary" />,
+    letter: 'R3',
+    title: 'Rutina',
+    subtitle: 'Los Hábitos',
+    description: 'Microrrutinas que hacen que el bienestar sea automático, no una lucha diaria.',
   },
   {
-    icon: <TrendingUp className="h-8 w-8 text-primary" />,
-    title: 'Resultados (Tu Éxito)',
-    description: 'Seguimiento constante y ajustes en tiempo real. Métricas claras para que siempre sepas cuánto has avanzado.',
+    icon: <TrendingUp className="h-6 w-6 text-primary" />,
+    letter: 'R4',
+    title: 'Resultados',
+    subtitle: 'Tu Éxito',
+    description: 'Seguimiento constante y ajustes en tiempo real. Métricas claras de progreso.',
   },
 ];
 
 const MethodologySection = () => {
   return (
-    <section id="methodology">
-      <div className="container mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="text-center max-w-3xl mx-auto">
-          <h2 className="font-headline text-3xl md:text-4xl font-bold">Mi Método 4R: Rigor, Resistencia, Rutina y Resultados</h2>
+    <section id="methodology" className="bg-muted/40">
+      <div className="container mx-auto px-4 sm:px-6 lg:px-8 py-12">
+        <div className="text-center max-w-2xl mx-auto mb-8">
+          <h2 className="font-headline text-3xl md:text-4xl font-bold">El Método 4R</h2>
+          <p className="mt-3 text-muted-foreground">
+            La metodología detrás de todos los planes. El{' '}
+            <span className="font-semibold text-foreground">Programa Integral 4R</span> entrega los
+            cuatro pilares completos; los planes de Entrenamiento y Nutrición aplican los pilares
+            más relevantes para cada objetivo.
+          </p>
         </div>
-        <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-8 mt-12">
+
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
           {methodology.map((item) => (
-            <Card key={item.title} className="text-center shadow-md hover:shadow-xl transition-shadow">
-              <CardHeader className="items-center">
-                <div className="bg-primary/10 p-4 rounded-full">
-                  {item.icon}
-                </div>
-                <CardTitle className="font-headline pt-4">{item.title}</CardTitle>
-              </CardHeader>
-              <CardContent>
-                <p className="text-muted-foreground">{item.description}</p>
-              </CardContent>
-            </Card>
+            <div
+              key={item.title}
+              className="flex flex-col items-center text-center bg-background rounded-xl p-5 shadow-sm"
+            >
+              <div className="flex items-center justify-center bg-primary/10 rounded-full p-3 mb-3">
+                {item.icon}
+              </div>
+              <span className="text-xs font-bold text-primary/60 uppercase tracking-widest mb-0.5">
+                {item.letter}
+              </span>
+              <p className="font-headline font-bold text-base">{item.title}</p>
+              <p className="text-xs text-primary font-medium mb-2">{item.subtitle}</p>
+              <p className="text-sm text-muted-foreground leading-snug">{item.description}</p>
+            </div>
           ))}
         </div>
       </div>

--- a/src/components/sections/services-section.tsx
+++ b/src/components/sections/services-section.tsx
@@ -1,20 +1,36 @@
 import Link from 'next/link';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
-import { BrainCircuit, Dumbbell } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { Dumbbell, Apple, Star } from 'lucide-react';
 
 const services = [
   {
-    icon: <BrainCircuit className="h-10 w-10 text-primary" />,
-    title: 'Diseño de Hábitos Saludables para una Vida de Alto Rendimiento',
-    subtitle: 'Asesoría de Hábitos Saludables (El Pilar)',
-    description: 'Un plan integral que va más allá del gimnasio. Usando mi enfoque sistemático, identificamos y optimizamos tu alimentación, tu manejo del estrés y tu calidad de sueño. Creamos rutinas diarias inquebrantables que te impulsan a ser tu mejor versión sin esfuerzo.',
+    icon: <Dumbbell className="h-10 w-10 text-primary" />,
+    subtitle: 'Entrenamiento Personalizado',
+    title: 'Programas de Entrenamiento Personalizados con Rigor de Ingeniero',
+    description:
+      'No más entrenamientos genéricos. Recibe un plan de fitness totalmente individualizado basado en tus objetivos específicos (pérdida de peso, fuerza, resistencia en montaña o running). Progresión lógica que garantiza resultados.',
+    methodTags: ['Rigor', 'Resistencia'],
+    badge: null,
   },
   {
-    icon: <Dumbbell className="h-10 w-10 text-primary" />,
-    title: 'Programas de Entrenamiento Personalizados con Rigor de Ingeniero',
-    subtitle: 'Entrenamiento Personal Online/Presencial (La Ejecución)',
-    description: 'No más entrenamientos genéricos. Recibe un plan de fitness totalmente individualizado basado en tus objetivos específicos (pérdida de peso, fuerza, resistencia en montaña o running). Te guiaré paso a paso, aplicando la progresión lógica que garantiza resultados.',
+    icon: <Apple className="h-10 w-10 text-primary" />,
+    subtitle: 'Asesoría Nutricional',
+    title: 'Diseño de una Dieta Personalizada para una Vida de Alto Rendimiento',
+    description:
+      'Un plan dietético integral adaptado a tu estilo de vida, tus preferencias y tus objetivos de salud y rendimiento. Nutrición que trabaja con tu entrenamiento, no contra él.',
+    methodTags: ['Rigor', 'Rutina'],
+    badge: null,
+  },
+  {
+    icon: <Star className="h-10 w-10 text-primary" />,
+    subtitle: 'Programa Integral 4R',
+    title: 'Entrenamiento, Nutrición y Hábitos: Tu Plan Estratégico hacia Resultados Duraderos',
+    description:
+      'El único plan que combina los cuatro pilares del Método 4R en una estrategia unificada. Entrenamiento, nutrición, hábitos y soporte continuado para construir una vida de alto rendimiento.',
+    methodTags: ['Rigor', 'Resistencia', 'Rutina', 'Resultados'],
+    badge: 'Método 4R completo',
   },
 ];
 
@@ -23,28 +39,49 @@ const ServicesSection = () => {
     <section id="services">
       <div className="container mx-auto px-4 sm:px-6 lg:px-8">
         <div className="text-center max-w-3xl mx-auto">
-          <h2 className="font-headline text-3xl md:text-4xl font-bold">Servicios de Asesoría y Entrenamiento Personal</h2>
-           <p className="mt-4 text-lg text-muted-foreground">Tu Ruta hacia el Éxito</p>
+          <h2 className="font-headline text-3xl md:text-4xl font-bold">
+            Elige el Plan que se Adapta a Ti
+          </h2>
+          <p className="mt-4 text-lg text-muted-foreground">
+            Tres programas construidos sobre el Método 4R — desde el foco en entrenamiento o
+            nutrición hasta el plan integral que lo abarca todo.
+          </p>
         </div>
 
-        <div className="grid md:grid-cols-2 gap-8 mt-12">
+        <div className="grid md:grid-cols-3 gap-8 mt-12">
           {services.map((service) => (
-            <Card key={service.title} className="flex flex-col shadow-lg">
-              <CardHeader className="flex-row items-start gap-4">
-                <div className="bg-primary/10 p-4 rounded-full mt-1">
-                 {service.icon}
-                </div>
-                <div>
-                    <p className="text-sm font-semibold text-primary">{service.subtitle}</p>
-                    <CardTitle className="font-headline text-2xl mt-1">{service.title}</CardTitle>
-                </div>
+            <Card key={service.subtitle} className="flex flex-col shadow-lg relative">
+              {service.badge && (
+                <Badge className="absolute -top-3 left-1/2 -translate-x-1/2 bg-primary text-primary-foreground px-4 py-1 text-sm whitespace-nowrap">
+                  {service.badge}
+                </Badge>
+              )}
+              <CardHeader className="items-center text-center pt-8">
+                <div className="bg-primary/10 p-4 rounded-full mb-2">{service.icon}</div>
+                <p className="text-sm font-semibold text-primary uppercase tracking-wide">
+                  {service.subtitle}
+                </p>
+                <CardTitle className="font-headline text-xl mt-1 leading-snug">
+                  {service.title}
+                </CardTitle>
               </CardHeader>
-              <CardContent className="flex-grow">
+              <CardContent className="flex flex-col flex-grow gap-4">
                 <CardDescription className="text-base">{service.description}</CardDescription>
+                <div className="flex flex-wrap gap-2 mt-auto pt-2">
+                  {service.methodTags.map((tag) => (
+                    <span
+                      key={tag}
+                      className="text-xs font-medium bg-primary/10 text-primary px-2 py-0.5 rounded-full"
+                    >
+                      {tag}
+                    </span>
+                  ))}
+                </div>
               </CardContent>
             </Card>
           ))}
         </div>
+
         <div className="text-center mt-12">
           <Button size="lg" variant="outline" asChild>
             <Link href="/planes">Ver Planes y Tarifas</Link>


### PR DESCRIPTION
## Problem

Three disconnected sections created reading fatigue and terminology mismatch:
- **Servicios** had 2 cards (Asesoría de Hábitos / Entrenamiento) but **Tarifas** has 3 plans (Entrenamiento, Nutrición, Integral 4R) — the user had to mentally re-map.
- **Método 4R** explained 4 R's but their relationship to specific pricing tiers was purely implicit.
- 4 full methodology cards + 2 service cards + 3 pricing cards = a very long repetitive stack.

## Approach chosen: Option B

**Restructure Servicios around the three pricing tiers; keep Método 4R as a compact horizontal band.**

This was preferred over Option A (merging into one section) because it preserves the existing section IDs (`#services`, `#methodology`) and the logical separation that page navigation depends on. It was preferred over Option C because it requires fewer layout changes and keeps the page structure intact.

## Changes

### `services-section.tsx`
- Replaced 2-card grid with **3-card grid** (1 col on mobile → 3 on desktop) matching the pricing tiers exactly: **Entrenamiento Personalizado**, **Asesoría Nutricional**, **Programa Integral 4R**.
- Each card uses the same subtitle, icon, and order as the Planes y Tarifas page, so users can trace a 1:1 line between services and pricing.
- Added **method tags** (colored pills: R1 Rigor, R2 Resistencia, etc.) at the bottom of each card showing which 4R pillars the plan covers:
  - Entrenamiento → Rigor, Resistencia
  - Nutrición → Rigor, Rutina
  - Programa Integral 4R → Rigor, Resistencia, Rutina, Resultados (all four)
- Added a **"Método 4R completo"** badge on the Integral 4R card to make the connection visually explicit at a glance.
- Updated the section heading from the generic "Servicios de Asesoría y Entrenamiento Personal" to "Elige el Plan que se Adapta a Ti" — user-focused framing that leads naturally to the CTA.
- Kept the "Ver Planes y Tarifas" CTA button.

### `methodology-section.tsx`
- Replaced 4 full `<Card>` blocks with **4 compact tiles** (2-col on mobile → 4-col on desktop) that take up significantly less vertical space.
- Added a descriptive sub-header explicitly stating: *"El Programa Integral 4R entrega los cuatro pilares completos; los planes de Entrenamiento y Nutrición aplican los pilares más relevantes para cada objetivo."*
- Each tile now shows a letter label (R1–R4) to reinforce the visual language used in the service card tags.
- Added `bg-muted/40` section background to visually differentiate it from the white service cards flanking it, creating a natural "band" feel between sections.

## Acceptance criteria check

- ✅ Servicios now has 3 cards, naming matches the three pricing tiers exactly.
- ✅ The 4R method and Programa Integral 4R are visually connected: tags show all 4 pillars, badge says "Método 4R completo", and the methodology section sub-header names it explicitly.
- ✅ A first-time visitor can scan services → method → pricing without re-mapping terminology.
- ✅ Vertical space reduced: 4 compact tiles replace 4 large cards; service grid is 3-col (more horizontal, less vertical).
- ✅ Responsive: 2-col on mobile for methodology tiles; 1-col → 3-col for service cards.
- ✅ TypeScript: `npx tsc --noEmit` passes.

## Out of scope

Pricing values, plan contents, commercial strategy, Sobre Mí / Contacto sections, visual rebrand.

Closes #7