### PR TITLE
fix(toast): reduce TOAST_REMOVE_DELAY to 5000ms

### DIFF
--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -9,7 +9,7 @@ import type {
 } from "@/components/ui/toast"
 
 const TOAST_LIMIT = 1
-const TOAST_REMOVE_DELAY = 1000000
+const TOAST_REMOVE_DELAY = 5000
 
 type ToasterToast = ToastProps & {
   id: string


### PR DESCRIPTION
## Summary
- Lower `TOAST_REMOVE_DELAY` in `src/hooks/use-toast.ts` from `1000000` ms (~16.7 minutes) to `5000` ms.
- Toasts now auto-remove from the DOM ~5s after they close, matching the standard shadcn/ui pattern.

Closes #29

## Test plan
- [ ] Trigger a toast (e.g. submit the contact form) and confirm it dismisses on its own and is removed from the DOM ~5s later.
- [ ] Manually closing a toast still removes it from the DOM after the same 5s window (no lingering nodes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)