### PR TITLE
fix(seo): remove servesCuisine: undefined from LocalBusiness JSON-LD

### DIFF
--- a/src/components/structured-data.tsx
+++ b/src/components/structured-data.tsx
@@ -37,7 +37,6 @@ const localBusiness = {
     { '@type': 'City', name: 'Vallecas' },
     { '@type': 'Country', name: 'España' },
   ],
-  servesCuisine: undefined,
   sameAs: [instagramUrl],
   priceRange: '€€',
 };


### PR DESCRIPTION
## Summary
- Drop the dead `servesCuisine: undefined` field from the `localBusiness` schema in `src/components/structured-data.tsx`. It is a food-service property irrelevant to a fitness/personal-training business.
- `JSON.stringify` already drops `undefined`, so this is a no-op at runtime — the change just removes misleading dead code.

Closes #32

## Test plan
- [ ] Build the site and view source on the homepage; confirm no `servesCuisine` key appears in the rendered LocalBusiness JSON-LD.
- [ ] Run the schema through Google's Rich Results Test to verify it still validates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)