### PR TITLE
fix(seo): use static dates for sitemap lastModified

### DIFF
--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -6,19 +6,19 @@ export default function sitemap(): MetadataRoute.Sitemap {
   return [
     {
       url: siteUrl,
-      lastModified: new Date(),
+      lastModified: new Date('2025-01-01'),
       changeFrequency: 'monthly',
       priority: 1,
     },
     {
       url: `${siteUrl}/faq`,
-      lastModified: new Date(),
+      lastModified: new Date('2025-01-01'),
       changeFrequency: 'monthly',
       priority: 0.7,
     },
     {
       url: `${siteUrl}/legal`,
-      lastModified: new Date(),
+      lastModified: new Date('2025-01-01'),
       changeFrequency: 'yearly',
       priority: 0.3,
     },


### PR DESCRIPTION
## Summary
- Replace `new Date()` in `src/app/sitemap.ts` with a static `new Date('2025-01-01')` for all three sitemap entries (homepage, /faq, /legal).
- Stops every deployment from falsely advertising fresh content to crawlers; the static date should be bumped manually when a page's content actually changes.

Closes #25

## Test plan
- [ ] `npm run build && npm start` and request `/sitemap.xml`; confirm every `<lastmod>` reads `2025-01-01` rather than the current build time.
- [ ] Re-deploy and check that the timestamps don't drift between builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)